### PR TITLE
Feat: Menu CRUD image제외 구현완료

### DIFF
--- a/src/main/java/com/example/miniprojectdelivery/controller/MemuController.java
+++ b/src/main/java/com/example/miniprojectdelivery/controller/MemuController.java
@@ -24,5 +24,9 @@ public class MemuController {
     public List<MemuResponseDto> getMenus(){
         return menuService.getMenus();
     }
+    @GetMapping("/menus/{id}")
+    public MemuResponseDto selectMenu(@PathVariable Long id){
+        return menuService.selectMenu(id);
+    }
 
 }

--- a/src/main/java/com/example/miniprojectdelivery/controller/MemuController.java
+++ b/src/main/java/com/example/miniprojectdelivery/controller/MemuController.java
@@ -28,5 +28,8 @@ public class MemuController {
     public MemuResponseDto selectMenu(@PathVariable Long id){
         return menuService.selectMenu(id);
     }
-
+    @PutMapping("/menus/{id}")
+    public MemuResponseDto updateMenu(@PathVariable Long id, @RequestBody MenuRequestDto requestDto){
+        return menuService.update(id, requestDto);
+    }
 }

--- a/src/main/java/com/example/miniprojectdelivery/controller/MemuController.java
+++ b/src/main/java/com/example/miniprojectdelivery/controller/MemuController.java
@@ -1,0 +1,24 @@
+package com.example.miniprojectdelivery.controller;
+
+import com.example.miniprojectdelivery.dto.MemuResponseDto;
+import com.example.miniprojectdelivery.dto.MenuRequestDto;
+import com.example.miniprojectdelivery.dto.MessageResponseDto;
+import com.example.miniprojectdelivery.service.MenuService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MemuController {
+
+    private final MenuService menuService;
+
+    @PostMapping("/menus")
+    public MemuResponseDto createMenu(@RequestBody MenuRequestDto requestDto){
+        return menuService.createMenu(requestDto);
+    }
+}

--- a/src/main/java/com/example/miniprojectdelivery/controller/MemuController.java
+++ b/src/main/java/com/example/miniprojectdelivery/controller/MemuController.java
@@ -2,10 +2,8 @@ package com.example.miniprojectdelivery.controller;
 
 import com.example.miniprojectdelivery.dto.MemuResponseDto;
 import com.example.miniprojectdelivery.dto.MenuRequestDto;
-import com.example.miniprojectdelivery.dto.MessageResponseDto;
 import com.example.miniprojectdelivery.service.MenuService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,4 +19,10 @@ public class MemuController {
     public MemuResponseDto createMenu(@RequestBody MenuRequestDto requestDto){
         return menuService.createMenu(requestDto);
     }
+
+    @GetMapping("/menus")
+    public List<MemuResponseDto> getMenus(){
+        return menuService.getMenus();
+    }
+
 }

--- a/src/main/java/com/example/miniprojectdelivery/controller/MemuController.java
+++ b/src/main/java/com/example/miniprojectdelivery/controller/MemuController.java
@@ -2,8 +2,10 @@ package com.example.miniprojectdelivery.controller;
 
 import com.example.miniprojectdelivery.dto.MemuResponseDto;
 import com.example.miniprojectdelivery.dto.MenuRequestDto;
+import com.example.miniprojectdelivery.dto.MessageResponseDto;
 import com.example.miniprojectdelivery.service.MenuService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -31,5 +33,9 @@ public class MemuController {
     @PutMapping("/menus/{id}")
     public MemuResponseDto updateMenu(@PathVariable Long id, @RequestBody MenuRequestDto requestDto){
         return menuService.update(id, requestDto);
+    }
+    @DeleteMapping("/menus/{id}")
+    public ResponseEntity<MessageResponseDto> deleteMenu(@PathVariable Long id){
+        return menuService.deleteMenu(id);
     }
 }

--- a/src/main/java/com/example/miniprojectdelivery/dto/MemuResponseDto.java
+++ b/src/main/java/com/example/miniprojectdelivery/dto/MemuResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.miniprojectdelivery.dto;
+
+import com.example.miniprojectdelivery.model.Menu;
+import lombok.Getter;
+
+
+@Getter
+public class MemuResponseDto {
+    public Long id;
+    private Long restaurantId;
+    private String image; // S3연동예정, 더미필드(임시)
+    private String name;
+    private int cost;
+
+    public MemuResponseDto(Menu menu) {
+        this.id = menu.getId();
+        this.restaurantId = menu.getRestaurant().getId();
+        this.image = menu.getImage();
+        this.name = menu.getName();
+        this.cost = menu.getCost();
+    }
+}

--- a/src/main/java/com/example/miniprojectdelivery/dto/MenuRequestDto.java
+++ b/src/main/java/com/example/miniprojectdelivery/dto/MenuRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.miniprojectdelivery.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MenuRequestDto {
+    private Long restaurantId;
+    private String image; // S3연동예정, 더미필드(임시)
+    private String name;
+    private int cost;
+}

--- a/src/main/java/com/example/miniprojectdelivery/dto/MessageResponseDto.java
+++ b/src/main/java/com/example/miniprojectdelivery/dto/MessageResponseDto.java
@@ -1,0 +1,9 @@
+package com.example.miniprojectdelivery.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter @AllArgsConstructor
+public class MessageResponseDto {
+    private String msg;
+}

--- a/src/main/java/com/example/miniprojectdelivery/model/Menu.java
+++ b/src/main/java/com/example/miniprojectdelivery/model/Menu.java
@@ -1,0 +1,46 @@
+package com.example.miniprojectdelivery.model;
+
+import com.example.miniprojectdelivery.dto.MenuRequestDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "menu")
+public class Menu {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne   // Restaurant에서 @OneToMany 필요함
+    @JoinColumn(name = "restaurant_id")
+    private Restaurant restaurant;
+
+    @Column(nullable = false)
+    private String image;  // S3연동예정, 더미필드(임시)
+    @Column(nullable = false)
+    private String name;
+    @Column(nullable = false)
+    private int cost;
+
+    public Menu(MenuRequestDto requestDto, Restaurant restaurant) {
+        this.id = getId();
+        this.restaurant = restaurant; // 임의 Restaurant 생성
+        this.image = requestDto.getImage();
+        this.name = requestDto.getName();
+        this.cost = requestDto.getCost();
+    }
+
+
+    public void update(MenuRequestDto requestDto) {
+        this.image = requestDto.getImage();
+        this.name = requestDto.getName();
+        this.cost = requestDto.getCost();
+    }
+}

--- a/src/main/java/com/example/miniprojectdelivery/model/Restaurant.java
+++ b/src/main/java/com/example/miniprojectdelivery/model/Restaurant.java
@@ -1,0 +1,25 @@
+package com.example.miniprojectdelivery.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter @Setter
+@NoArgsConstructor
+public class Restaurant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "restaurant", cascade = CascadeType.REMOVE)
+    private List<Menu> menuList = new ArrayList<>();
+}

--- a/src/main/java/com/example/miniprojectdelivery/repository/MenuRepository.java
+++ b/src/main/java/com/example/miniprojectdelivery/repository/MenuRepository.java
@@ -1,0 +1,7 @@
+package com.example.miniprojectdelivery.repository;
+
+import com.example.miniprojectdelivery.model.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+}

--- a/src/main/java/com/example/miniprojectdelivery/repository/RestaurantRepository.java
+++ b/src/main/java/com/example/miniprojectdelivery/repository/RestaurantRepository.java
@@ -1,0 +1,7 @@
+package com.example.miniprojectdelivery.repository;
+
+import com.example.miniprojectdelivery.model.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+}

--- a/src/main/java/com/example/miniprojectdelivery/service/MenuService.java
+++ b/src/main/java/com/example/miniprojectdelivery/service/MenuService.java
@@ -2,17 +2,13 @@ package com.example.miniprojectdelivery.service;
 
 import com.example.miniprojectdelivery.dto.MemuResponseDto;
 import com.example.miniprojectdelivery.dto.MenuRequestDto;
-import com.example.miniprojectdelivery.dto.MessageResponseDto;
 import com.example.miniprojectdelivery.model.Menu;
 import com.example.miniprojectdelivery.model.Restaurant;
 import com.example.miniprojectdelivery.repository.MenuRepository;
 import com.example.miniprojectdelivery.repository.RestaurantRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
 import java.util.List;
 
 @Service
@@ -26,5 +22,10 @@ public class MenuService {
                 ()-> new IllegalArgumentException("음식점을 찾을 수 없습니다"));
         Menu menu = menuRepository.save(new Menu(requestDto, restaurant));
        return new MemuResponseDto(menu);
+    }
+
+    public List<MemuResponseDto> getMenus() {
+        List<Menu> menuList = menuRepository.findAll();
+        return menuList.stream().map(MemuResponseDto::new).toList();
     }
 }

--- a/src/main/java/com/example/miniprojectdelivery/service/MenuService.java
+++ b/src/main/java/com/example/miniprojectdelivery/service/MenuService.java
@@ -28,4 +28,15 @@ public class MenuService {
         List<Menu> menuList = menuRepository.findAll();
         return menuList.stream().map(MemuResponseDto::new).toList();
     }
+
+    public MemuResponseDto selectMenu(Long id) {
+        Menu menu = findMenu(id);
+        return new MemuResponseDto(menu);
+    }
+
+    // 선택한 메뉴가 존재하는지 검사하는 메서드
+    private Menu findMenu(Long id) {
+        return menuRepository.findById(id).orElseThrow(() ->
+                new IllegalArgumentException("선택한 메뉴는 존재하지 않습니다."));
+    }
 }

--- a/src/main/java/com/example/miniprojectdelivery/service/MenuService.java
+++ b/src/main/java/com/example/miniprojectdelivery/service/MenuService.java
@@ -1,0 +1,30 @@
+package com.example.miniprojectdelivery.service;
+
+import com.example.miniprojectdelivery.dto.MemuResponseDto;
+import com.example.miniprojectdelivery.dto.MenuRequestDto;
+import com.example.miniprojectdelivery.dto.MessageResponseDto;
+import com.example.miniprojectdelivery.model.Menu;
+import com.example.miniprojectdelivery.model.Restaurant;
+import com.example.miniprojectdelivery.repository.MenuRepository;
+import com.example.miniprojectdelivery.repository.RestaurantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MenuService {
+
+    private final MenuRepository menuRepository;
+    private final RestaurantRepository restaurantRepository;
+    public MemuResponseDto createMenu(MenuRequestDto requestDto) {
+        Restaurant restaurant = restaurantRepository.findById(requestDto.getRestaurantId()).orElseThrow(
+                ()-> new IllegalArgumentException("음식점을 찾을 수 없습니다"));
+        Menu menu = menuRepository.save(new Menu(requestDto, restaurant));
+       return new MemuResponseDto(menu);
+    }
+}

--- a/src/main/java/com/example/miniprojectdelivery/service/MenuService.java
+++ b/src/main/java/com/example/miniprojectdelivery/service/MenuService.java
@@ -9,6 +9,7 @@ import com.example.miniprojectdelivery.repository.RestaurantRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.List;
 
 @Service
@@ -38,5 +39,12 @@ public class MenuService {
     private Menu findMenu(Long id) {
         return menuRepository.findById(id).orElseThrow(() ->
                 new IllegalArgumentException("선택한 메뉴는 존재하지 않습니다."));
+    }
+
+    @Transactional
+    public MemuResponseDto update(Long id, MenuRequestDto requestDto) {
+        Menu menu = findMenu(id);
+        menu.update(requestDto);
+        return new MemuResponseDto(menu);
     }
 }

--- a/src/main/java/com/example/miniprojectdelivery/service/MenuService.java
+++ b/src/main/java/com/example/miniprojectdelivery/service/MenuService.java
@@ -2,11 +2,14 @@ package com.example.miniprojectdelivery.service;
 
 import com.example.miniprojectdelivery.dto.MemuResponseDto;
 import com.example.miniprojectdelivery.dto.MenuRequestDto;
+import com.example.miniprojectdelivery.dto.MessageResponseDto;
 import com.example.miniprojectdelivery.model.Menu;
 import com.example.miniprojectdelivery.model.Restaurant;
 import com.example.miniprojectdelivery.repository.MenuRepository;
 import com.example.miniprojectdelivery.repository.RestaurantRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -34,17 +37,22 @@ public class MenuService {
         Menu menu = findMenu(id);
         return new MemuResponseDto(menu);
     }
-
-    // 선택한 메뉴가 존재하는지 검사하는 메서드
-    private Menu findMenu(Long id) {
-        return menuRepository.findById(id).orElseThrow(() ->
-                new IllegalArgumentException("선택한 메뉴는 존재하지 않습니다."));
-    }
-
     @Transactional
     public MemuResponseDto update(Long id, MenuRequestDto requestDto) {
         Menu menu = findMenu(id);
         menu.update(requestDto);
         return new MemuResponseDto(menu);
     }
+    public ResponseEntity<MessageResponseDto> deleteMenu(Long id) {
+        Menu menu = findMenu(id);
+        return ResponseEntity.status(HttpStatus.OK).body(new MessageResponseDto("메뉴 삭제 성공!"));
+
+    }
+    // 선택한 메뉴가 존재하는지 검사하는 메서드
+    private Menu findMenu(Long id) {
+        return menuRepository.findById(id).orElseThrow(() ->
+                new IllegalArgumentException("선택한 메뉴는 존재하지 않습니다."));
+    }
+
+
 }


### PR DESCRIPTION
### ❗️ 연관 이슈 (있을 경우 작성)

### ✅ 작업 내용
Menu CRUD 구현완료입니다.
단, image 저장을 S3로 진행할 예정이라 더미필드로 구현했습니다.
월요일까지 이미지 S3 구현이 어려울 경우 디렉토리+서비스로 Menu image 저장을 구현하겠습니다.

음식점과 메뉴는 1:N관계입니다.
음식점은 담당하시는분이 있기 때문에 확인차 최소볼륨으로 임시작성 했습니다.

메뉴는 음식점들 마다 설정할 수 있으며, 메뉴 생성시 주소창  path가 아니라 프론트에서 MenuRequestDto를 보낼 때  restaurantId를 받아오게끔 설정했습니다.


### 🔗 적용 브랜치

jihyeon/develop/features/Menu_NohJihyeon -> Junyeong/develop

### 📢 리뷰 요구사항
원본